### PR TITLE
Subgroup by cohorts from ScyllaCharacterization

### DIFF
--- a/R/CreateCohorts.R
+++ b/R/CreateCohorts.R
@@ -126,6 +126,12 @@ createCohorts <- function(connectionDetails,
                                                      targetIds = targetCohortIds,
                                                      oracleTempSchema = oracleTempSchema)
 
+  ScyllaCharacterization::createBulkSubgroupFromCohorts(connection = connection,
+                                                        cohortDatabaseSchema = cohortDatabaseSchema,
+                                                        cohortStagingTable = cohortTable,
+                                                        targetIds = targetCohortIds,
+                                                        oracleTempSchema = oracleTempSchema)
+
   # Create negative control outcomes
   ParallelLogger::logInfo(" ---- Creating negative control outcome cohorts ---- ")
   negativeControls <- getNegativeControlOutcomes()


### PR DESCRIPTION
The protocol requires that we assess the comparative effectiveness and safety among treatments administered after COVID positive testing and prior to hospitalization. To do this, we'll use the subgroupId == 2002 from the ScyllaCharacterization package. 

The call to `ScyllaCharacterization::createBulkSubgroupFromCohorts` will take all of the target cohorts and subset them by all of the subgroup cohorts as defined in: [CohortsToCreateSubgroup.csv](https://github.com/ohdsi-studies/ScyllaCharacterization/blob/master/inst/settings/CohortsToCreateSubgroup.csv). This will include the subgroupId == 2002 but also many others so let me know if you have any questions/concerns.